### PR TITLE
#170764588 Mark notifications as read

### DIFF
--- a/src/controllers/notification.controller.js
+++ b/src/controllers/notification.controller.js
@@ -1,0 +1,72 @@
+import NotificationRepository from '../repositories/notification.repository';
+
+const notificationRepository = new NotificationRepository();
+
+class NotificationController {
+  /**
+   *
+   * @param {*} req
+   * @param {*} res
+   * @param {*} next
+   * @returns {*} message
+   */
+  static async markAllNotificationsRead(req, res) {
+    try {
+      const { userData } = req;
+      await notificationRepository.update({ user_id: userData.id }, { status: 'read' });
+      return res
+        .status(200)
+        .json({
+          status: res.statusCode,
+          message: 'All notifications are marked as read'
+        });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: error.message });
+    }
+  }
+
+  /**
+  *
+  * @param {*} req
+  * @param {*} res
+  * @param {*} next
+  * @returns {*} res
+  */
+  static async markOneNotificationRead(req, res) {
+    try {
+      const id = Number(req.params.id);
+      const notificationFound = await notificationRepository.findById(id);
+      if (!notificationFound) {
+        res.status(404).json({ status: 404, error: 'Notification not found' });
+      }
+
+      await notificationRepository.update({ id }, { status: 'read' });
+      return res.status(200).json({ status: 200, message: 'Notification marked as read' });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: error.message });
+    }
+  }
+
+  /**
+  *
+  * @param {*} req
+  * @param {*} res
+  * @param {*} next
+  * @returns {*} res
+  */
+  static async markOneNotificationUnread(req, res) {
+    try {
+      const id = Number(req.params.id);
+      const notificationFound = await notificationRepository.findById(id);
+      if (!notificationFound) {
+        res.status(404).json({ status: 404, error: 'Notification not found' });
+      }
+
+      await notificationRepository.update({ id }, { status: 'unread' });
+      return res.status(200).json({ status: 200, message: 'Notification marked as unread' });
+    } catch (error) {
+      return res.status(500).json({ status: 500, error: error.message });
+    }
+  }
+}
+export default NotificationController;

--- a/src/database/migrations/20200204215248-create-notification.js
+++ b/src/database/migrations/20200204215248-create-notification.js
@@ -1,0 +1,35 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Notifications', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user_id: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'user_id',
+      },
+    },
+    status: {
+      type: Sequelize.STRING,
+      defaultValue: 'unread',
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('NOW')
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('NOW')
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Notifications')
+};

--- a/src/database/seeders/20200121122716-create-user.js
+++ b/src/database/seeders/20200121122716-create-user.js
@@ -11,6 +11,35 @@ export default {
     role: 'super-administrator',
     password: await hashPassword('Kemmy123'),
     isVerified: true
+  },
+  {
+    email: 'fantastic6@gmail.com',
+    user_name: 'great',
+    first_name: 'Fantastic',
+    last_name: 'Bro',
+    role: 'requester',
+    password: await hashPassword('Kemmy123'),
+    line_manager: 'fantastic4@gmail.com',
+    isVerified: true
+  },
+  {
+    email: 'fantastic5@gmail.com',
+    user_name: 'great',
+    first_name: 'Fantastic',
+    last_name: 'Bro',
+    role: 'requester',
+    password: await hashPassword('Kemmy123'),
+    line_manager: 'fantastic4@gmail.com',
+    isVerified: true
+  },
+  {
+    email: 'fantastic4@gmail.com',
+    user_name: 'great',
+    first_name: 'Fantastic',
+    last_name: 'Bro',
+    role: 'manager',
+    password: await hashPassword('Kemmy123'),
+    isVerified: true
   }], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Users', null, {})

--- a/src/database/seeders/20200204232743-notification.js
+++ b/src/database/seeders/20200204232743-notification.js
@@ -1,0 +1,19 @@
+export default {
+  up: queryInterface => queryInterface.bulkInsert('Notifications', [{
+    user_id: 3,
+  },
+  {
+    user_id: 3,
+  },
+  {
+    user_id: 2,
+  },
+  {
+    user_id: 2,
+  },
+  {
+    user_id: 4,
+  }], {}),
+
+  down: queryInterface => queryInterface.bulkDelete('Notifications', null, {})
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,12 @@
 import authentication from './routes/authentication';
 import profile from './routes/profile.route';
+import notification from './routes/notification.route';
+
 
 export default (app) => {
   app.use('/api/auth', authentication);
   app.use('/api/profile', profile);
+  app.use('/api/notifications', notification);
 
   app.use((req, res, next) => {
     const err = new Error('Page not found');

--- a/src/middlewares/notification.middleware.js
+++ b/src/middlewares/notification.middleware.js
@@ -1,0 +1,24 @@
+import 'dotenv';
+import Response from '../utils/response';
+import NotificationSchema from '../modules/notification.schema';
+/**
+ * @description NotificationMiddleware checks if the notification ID is valid
+ */
+class NotificationMiddleware {
+  /**
+   * @param {req} req object
+   * @param {res} res object
+   * @param {next} next forwards to the next middleware function
+   * or controller if there is no middleware
+   * @returns {obj} returns a response object
+  */
+  static async param(req, res, next) {
+    const { error } = NotificationSchema.notificationParam(req.params);
+    if (error) {
+      const response = new Response(res, 400, error.message);
+      return response.sendErrorMessage();
+    }
+    return next();
+  }
+}
+export default NotificationMiddleware;

--- a/src/models/notification.js
+++ b/src/models/notification.js
@@ -1,0 +1,21 @@
+export default (sequelize, DataTypes) => {
+  const Notification = sequelize.define('Notification', {
+    user_id: DataTypes.INTEGER,
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'unread',
+      validate: {
+        isIn: {
+          args: [['unread', 'read']],
+          msg: 'Notification status can either be read or unread.'
+        }
+      }
+    }
+  }, {});
+  Notification.associate = (models) => {
+    // associations can be defined here
+    Notification.belongsTo(models.User, { foreignKey: 'user_id' });
+  };
+  return Notification;
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -96,6 +96,8 @@ export default (sequelize, DataTypes) => {
     },
     {}
   );
-
+  User.associate = models => {
+    User.hasMany(models.Notification, { foreignKey: 'user_id', as: 'notifications' });
+  };
   return User;
 };

--- a/src/modules/notification.schema.js
+++ b/src/modules/notification.schema.js
@@ -1,0 +1,29 @@
+import Joi from '@hapi/joi';
+/**
+ * @description NotificationSchema class validates user data
+*/
+class NotificationSchema {
+  /**
+   * @static
+   * @param {obj} data
+   * @returns {obj} returns schema object
+  */
+  static notificationParam(data) {
+    const schema = Joi.object({
+      id: Joi.number()
+        .integer()
+        .positive()
+        .min(1)
+        .messages({
+          'number.base': 'Parameter id must be a number',
+          'string.min': 'Parameter id  length must be at least {{#limit}} characters long',
+          'number.integer': 'Parameter id  must be an integer',
+          'number.positive': 'Parameter id  must be a positive number',
+          'number.unsafe': 'Parameter id  must be a safe number',
+          'any.required': 'Parameter id  is required',
+        }),
+    });
+    return schema.validate(data);
+  }
+}
+export default NotificationSchema;

--- a/src/repositories/notification.repository.js
+++ b/src/repositories/notification.repository.js
@@ -1,0 +1,48 @@
+import model from '../models';
+
+const { Notification } = model;
+/**
+ * @description NotificationRepository contains Notification repository
+ */
+class NotificationRepository {
+  /**
+   * @description constructor handles the Notification model
+   * Request Repository constructor
+   * @constructor
+   *
+   */
+  constructor() {
+    this.db = Notification;
+  }
+
+  /**
+   *
+   * @param {object} field
+   *
+   * @param {object} changes to update for notification status
+   *
+   * @returns {object} updated notification status
+   */
+  async update(field, changes) {
+    try {
+      return await this.db.update(changes, { returning: true, where: field });
+    } catch (e) {
+      throw new Error(e);
+    }
+  }
+
+  /**
+     *
+     * @param {integer} id
+     * @returns {obj} record is object if id found or null if not
+     */
+  async findById(id) {
+    try {
+      const record = await this.db.findByPk(id);
+      return record;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+}
+export default NotificationRepository;

--- a/src/routes/notification.route.js
+++ b/src/routes/notification.route.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import Notification from '../controllers/notification.controller';
+import AuthMiddleware from '../middlewares/auth.middleware';
+import NotificationMiddleware from '../middlewares/notification.middleware';
+
+const router = express.Router();
+
+router.patch('/', AuthMiddleware.verifyToken, Notification.markAllNotificationsRead);
+router.patch('/:id/read', NotificationMiddleware.param, AuthMiddleware.verifyToken, Notification.markOneNotificationRead);
+router.patch('/:id/unread', NotificationMiddleware.param, AuthMiddleware.verifyToken, Notification.markOneNotificationUnread);
+
+export default router;

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -8,6 +8,7 @@ import profile from './profile.test';
 import verification from './email.verification.test';
 import assignRole from './assignRole.test';
 import socialLogin from './socialLogin.test';
+import notification from './notification.test';
 
 describe('API test', () => {
   describe('Server test', server);
@@ -20,4 +21,5 @@ describe('API test', () => {
   describe('Email Verification test', verification);
   describe('Register test', assignRole);
   describe('Social Login test', socialLogin);
+  describe('Notification test', notification);
 });

--- a/src/test/notification.test.js
+++ b/src/test/notification.test.js
@@ -1,0 +1,150 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../server';
+import UserProfile from '../controllers/user.profile.controller';
+
+chai.use(chaiHttp);
+const { request } = chai;
+
+let token2;
+const user = {
+  password: 'Kemmy123',
+  email: 'fantastic6@gmail.com'
+};
+
+before((done) => {
+  request(server)
+    .post('/api/auth/login')
+    .set('Accept', 'application/json')
+    .send(user)
+    .end(async (err, res) => {
+      const { token } = res.body.data;
+      token2 = token;
+      done();
+    });
+});
+
+it('Should mark notification as read', (done) => {
+  request(server)
+    .patch('/api/notifications/3/read')
+    .set('Accept', 'application/json')
+    .set('token', `Bearer ${token2}`)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('message');
+      return done();
+    });
+});
+
+it('Should mark all notifications as read', (done) => {
+  request(server)
+    .patch('/api/notifications')
+    .set('Accept', 'application/json')
+    .set('token', `Bearer ${token2}`)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('message');
+      return done();
+    });
+});
+
+it('Should mark notification as unread', (done) => {
+  request(server)
+    .patch('/api/notifications/1/unread')
+    .set('Accept', 'application/json')
+    .set('token', `Bearer ${token2}`)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.status(200);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('message');
+      return done();
+    });
+});
+it('Should mark notification as unread', (done) => {
+  request(server)
+    .patch('/api/notifications/105/unread')
+    .set('Accept', 'application/json')
+    .set('token', `Bearer ${token2}`)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.status(404);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('error');
+      return done();
+    });
+});
+it('Should not mark notification as read if the notification is not found', (done) => {
+  request(server)
+    .patch('/api/notifications/10')
+    .set('Accept', 'application/json')
+    .set('token', `Bearer ${token2}`)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.status(404);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('error');
+      return done();
+    });
+});
+
+it('Should not mark notification as read if the notification id is invalid', (done) => {
+  request(server)
+    .patch('/api/notifications/invalidId/read')
+    .set('Accept', 'application/json')
+    .set('token', `Bearer ${token2}`)
+    .end((err, res) => {
+      if (err) {
+        return done(err);
+      }
+      expect(res).to.have.status(400);
+      expect(res.body).to.be.an('object');
+      expect(res.body).to.have.a.property('error');
+      return done();
+    });
+});
+
+it('Should not return user profile data on 500 error', (done) => {
+  const res = {
+    status: () => ({
+      json: ({ st, err }) => ({ st, err })
+    })
+  };
+  const smpl = {
+    userData: { email: 'test@gmail.com' }
+  };
+  UserProfile.getUser(smpl, res).then(data => {
+    expect(data).to.eq(undefined);
+    done();
+  });
+});
+
+it('Should not update user profile on 500 error', (done) => {
+  const res = {
+    status: () => ({
+      json: ({ st, err }) => ({ st, err })
+    })
+  };
+  const smpl = {
+    userData: { id: 1, email: 'test@gmail.com' },
+    profileData: { password: 1 }
+  };
+  UserProfile.updateUser(smpl, res).then(data => {
+    expect(data).to.eq(undefined);
+    done();
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
- add a feature to mark one notification as read
- mark all notifications as read
- mark a marked read notification to unread
#### Description of Task to be completed?
- On API request, a specific notification will be marked as read
- On API request, a specific notification that is marked read will be marked as unread
- On API request, all notifications will be marked as read
#### How should this be manually tested?
- Clone this repo on your local machine, open your terminal and run npm i to install all dependencies
- start server npm run dev
- Use " api/notification/{notification_id}/read " to mark a specific notification as read
- Use " api/notification/{notification_id}/unread " to mark a specific notification as unread
- Use" api/notifications " to mark all notifications as read
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#170764588](https://www.pivotaltracker.com/story/show/170764588)

#### Screenshots (if appropriate)
![Screenshot from 2020-02-05 15-57-08](https://user-images.githubusercontent.com/21080338/73848732-597a3500-4831-11ea-8903-7ba94a6b7d10.png)
![Screenshot from 2020-02-05 15-57-19](https://user-images.githubusercontent.com/21080338/73848747-5ed77f80-4831-11ea-92da-c33edfd59e68.png)
![Screenshot from 2020-02-05 15-57-44](https://user-images.githubusercontent.com/21080338/73848754-60a14300-4831-11ea-9fb8-4b3bd38a0f2b.png)
![Screenshot from 2020-02-05 18-20-29](https://user-images.githubusercontent.com/21080338/73860472-445ad180-4844-11ea-8e48-2ea3d25f58ca.png)

#### Questions: None