### PR TITLE
#170764593 Remember user profile on request initiation

### DIFF
--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -1,0 +1,37 @@
+/* eslint-disable class-methods-use-this */
+import model from '../models';
+import { onError, onSuccess } from '../utils/response';
+import requestSchema from '../modules/requestSchema';
+
+const { Request } = model;
+
+class TripRequestInfo {
+  async oneWay(req, res, next) {
+    try {
+      const { error } = requestSchema.destinationSchema(req.body);
+      if (error) {
+        const errMsg = error.details[0].message.split('"').join('');
+        return onError(res, 400, errMsg);
+      }
+      const info = {
+        userId: req.userData.id,
+        passportName: req.body.passportName,
+        passportNumber: req.body.passportNumber,
+        gender: req.body.gender,
+        role: req.body.role,
+        dob: req.body.dob,
+        origin: req.body.origin,
+        destination: req.body.destination,
+        travelDate: req.body.travelDate,
+        reason: req.body.reason,
+        accommodation_id: req.body.accommodation_id
+      };
+      await Request.create(info);
+      onSuccess(res, 201, 'Your request has sent successfully, wait for approval');
+      return next();
+    } catch (ex) {
+      onError(res, 500, 'Internal Server Error');
+    }
+  }
+}
+export default new TripRequestInfo();

--- a/src/database/migrations/20200121121712-create-user.js
+++ b/src/database/migrations/20200121121712-create-user.js
@@ -89,6 +89,11 @@ export default {
       allowNull: true,
       type: Sequelize.STRING
     },
+    rememberMe: {
+      allowNull: true,
+      type: Sequelize.BOOLEAN,
+      defaultValue: false
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE,

--- a/src/database/migrations/20200205155029-trip-request.js
+++ b/src/database/migrations/20200205155029-trip-request.js
@@ -1,0 +1,70 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Requests', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    userId: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    passportName: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    passportNumber: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    gender: {
+      type: Sequelize.STRING,
+      allowNull: false,
+    },
+    role: {
+      type: Sequelize.STRING,
+      allowNull: false
+    },
+    dob: {
+      allowNull: true,
+      type: Sequelize.DATE
+    },
+    origin: {
+      allowNull: false,
+      type: Sequelize.STRING,
+    },
+    destination: {
+      allowNull: false,
+      type: Sequelize.STRING
+    },
+    travelDate: {
+      allowNull: false,
+      type: Sequelize.DATE,
+    },
+    reason: {
+      allowNull: false,
+      type: Sequelize.STRING
+    },
+    accommodation_id: {
+      allowNull: false,
+      type: Sequelize.INTEGER
+    },
+    isApproved: {
+      allowNull: false,
+      type: Sequelize.STRING,
+      defaultValue: 'pending'
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE,
+      defaultValue: Sequelize.fn('NOW')
+    },
+    updatedAt: {
+      allowNull: true,
+      type: Sequelize.DATE
+    },
+  }),
+
+  down: queryInterface => queryInterface.dropTable('Requests')
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 import authentication from './routes/authentication';
 import profile from './routes/profile.route';
 import notification from './routes/notification.route';
-
+import requests from './routes/requests';
 
 export default (app) => {
   app.use('/api/auth', authentication);
   app.use('/api/profile', profile);
   app.use('/api/notifications', notification);
+  app.use('/api/requests', requests);
 
   app.use((req, res, next) => {
     const err = new Error('Page not found');

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -100,6 +100,31 @@ class AuthMiddleware {
       next();
     }
   }
+
+  static async autoFill(req, res, next) {
+    const { dataValues } = await userRepository.findByUserId(req.userData.id);
+    const data = await userRepository.findRequestByUserId(dataValues.id);
+    if (!data) return next();
+    if (dataValues.rememberMe !== false) {
+      const {
+        passportName, passportNumber, gender, role, dob
+      } = data.dataValues;
+      req.body = {
+        ...req.body, passportName, passportNumber, gender, role, dob
+
+      };
+      return next();
+    }
+    next();
+  }
+
+  static async rememberMe(req) {
+    const check = req.body.rememberMe;
+    if (check === true) await userRepository.update({ id: req.userData.id }, { rememberMe: true });
+    if (check === false) {
+      await userRepository.update({ id: req.userData.id }, { rememberMe: false });
+    }
+  }
 }
 
 export default AuthMiddleware;

--- a/src/models/request.js
+++ b/src/models/request.js
@@ -1,0 +1,73 @@
+export default (sequelize, DataTypes) => {
+  const Request = sequelize.define(
+    'Request',
+    {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true,
+        type: DataTypes.INTEGER
+      },
+      userId: {
+        allowNull: false,
+        type: DataTypes.INTEGER
+      },
+      passportName: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      passportNumber: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      gender: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      role: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      dob: {
+        allowNull: true,
+        type: DataTypes.DATE
+      },
+      origin: {
+        allowNull: false,
+        type: DataTypes.STRING,
+      },
+      destination: {
+        allowNull: false,
+        type: DataTypes.STRING
+      },
+      travelDate: {
+        allowNull: false,
+        type: DataTypes.DATE,
+      },
+      reason: {
+        allowNull: false,
+        type: DataTypes.STRING
+      },
+      accommodation_id: {
+        allowNull: true,
+        type: DataTypes.NUMBER
+      },
+      isApproved: {
+        allowNull: false,
+        type: DataTypes.STRING,
+        defaultValue: 'pending'
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE,
+      },
+      updatedAt: {
+        allowNull: true,
+        type: DataTypes.DATE
+      },
+    },
+    {}
+  );
+
+  return Request;
+};

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -92,6 +92,11 @@ export default (sequelize, DataTypes) => {
         type: DataTypes.BOOLEAN,
         defaultValue: false,
         allowNull: false
+      },
+      rememberMe: {
+        allowNull: true,
+        type: DataTypes.BOOLEAN,
+        defaultValue: false
       }
     },
     {}

--- a/src/modules/requestSchema.js
+++ b/src/modules/requestSchema.js
@@ -1,0 +1,83 @@
+import Joi from '@hapi/joi';
+/**
+ * @description UserSchema class validates user data
+*/
+export default class requestSchema {
+  /**
+   * @static
+   * @param {obj} data
+   * @returns {obj} returns schema object
+  */
+  static destinationSchema(data) {
+    const schema = Joi.object().keys({
+      passportNumber: Joi.number()
+        .required()
+        .messages({
+          'string.base': 'passportNumber must be number',
+          'any.required': 'passportNumber is required',
+          'string.empty': 'passportNumber is not allowed to be empty'
+        }),
+      passportName: Joi.string()
+        .required()
+        .messages({
+          'string.base': 'passportName must be string',
+          'any.required': 'passportName is required',
+          'string.empty': 'passportName is not allowed to be empty'
+        }),
+      gender: Joi.string().trim().required().valid('Male', 'Female'),
+      role: Joi.string()
+        .trim()
+        .valid(
+          'travel-administrator',
+          'travel-team-member',
+          'manager',
+          'requester',
+          'super-administrator'
+        )
+        .required(),
+      dob: Joi.date()
+        .messages({
+          'date.base': 'dob must be a date',
+        }),
+      origin: Joi.string()
+        .trim()
+        .regex(/^[a-zA-Z]+,\s[a-zA-Z]+$/)
+        .required()
+        .min(2)
+        .messages({
+          'string.regex': '"origin" must be in Country, City format'
+        }),
+      destination: Joi.string()
+        .trim()
+        .regex(/^[a-zA-Z]+,\s[a-zA-Z]+$/)
+        .required()
+        .min(2)
+        .messages({
+          'any.regex': '"origin" must be in Country, City format'
+        }),
+      travelDate: Joi
+        .date()
+        .min(Date.now())
+        .required()
+        .messages({
+          'date.base': 'traval date must have format of yyyy-mm-dd',
+          'date.min': 'traval date must have format of yyyy- mm - dd and can not be in the past',
+        }),
+      reason: Joi.string()
+        .trim()
+        .required()
+        .min(3)
+        .messages({
+          'string.base': 'reason must be a string',
+          'string.min': 'reason length must be at least {{#limit}} characters long',
+          'any.required': 'reason is required',
+          'string.pattern.base': 'reason must be at least 3 characters long letter'
+        }),
+      accommodation_id: Joi.number()
+        .integer()
+        .required(),
+      rememberMe: Joi.optional()
+    });
+    return schema.validate(data);
+  }
+}

--- a/src/repositories/userRepository.js
+++ b/src/repositories/userRepository.js
@@ -1,6 +1,6 @@
 import model from '../models';
 
-const { User } = model;
+const { User, Request } = model;
 
 /**
  * @description UserRepository contains user repository
@@ -14,6 +14,7 @@ class UserRepository {
    */
   constructor() {
     this.db = User;
+    this.Request = Request;
   }
 
   /**
@@ -103,6 +104,20 @@ class UserRepository {
       const record = await this.db.findOne({ where: { id } });
 
       return record;
+    } catch (error) {
+      throw new Error(error);
+    }
+  }
+
+  /**
+     *
+     * @param {integer} userId
+     * @returns {obj} Return Request found
+     */
+  async findRequestByUserId(userId) {
+    try {
+      const request = await this.Request.findOne({ where: { userId }, order: [['id', 'DESC']] });
+      return request;
     } catch (error) {
       throw new Error(error);
     }

--- a/src/routes/requests.js
+++ b/src/routes/requests.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import AuthMiddleware from '../middlewares/auth.middleware';
+import requestController from '../controllers/requestController';
+
+const router = express.Router();
+
+router.post('/one_way', AuthMiddleware.verifyToken, AuthMiddleware.autoFill, requestController.oneWay, AuthMiddleware.rememberMe);
+
+export default router;

--- a/src/test/autoFill.test.js
+++ b/src/test/autoFill.test.js
@@ -1,0 +1,80 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../server';
+import cont from '../controllers/requestController';
+
+require('../services/0auth');
+
+chai.use(chaiHttp);
+const { request } = chai;
+
+it('Registered user should be able to request a trip', (done) => {
+  request(server)
+    .post('/api/requests/one_way')
+    .set({ token: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJuYW1lQGV4YW1wbGUuY29tIiwiaWF0IjoxNTgwODkyNDM5fQ.xGAHCjyRKSGcsVHqiLGASfwGxmQHsNYRL_GY3uS34Ks' })
+    .send({
+      passportName: 'Boris Bihire',
+      passportNumber: '198700650',
+      gender: 'Female',
+      role: 'requester',
+      dob: '12/Nov/1673',
+      origin: 'Kigali, Rwanda',
+      destination: 'Nairobi, Kenya',
+      travelDate: '2020-02-29',
+      reason: 'lifeisshortjust chill',
+      accommodation_id: 3,
+      rememberMe: true
+    })
+    .end((error, response) => {
+      expect(response).to.have.status(201);
+      expect(response.body).to.be.a('object');
+      expect(response.body.status).to.be.equal(201);
+      done(error);
+    });
+});
+
+it('User should not request if there is server error', () => {
+  const res = {
+    status() {},
+    json() {}
+  };
+  const next = () => {};
+  const req = {
+    reasonable: 'lifeisshortjust chill',
+  };
+  cont.oneWay(req, res, next);
+});
+
+
+it('If he checked remember checkbox, App should be able to get his profile automatically  ', (done) => {
+  request(server)
+    .post('/api/requests/one_way')
+    .set({ token: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJuYW1lQGV4YW1wbGUuY29tIiwiaWF0IjoxNTgwODkyNDM5fQ.xGAHCjyRKSGcsVHqiLGASfwGxmQHsNYRL_GY3uS34Ks' })
+    .send({
+      origin: 'Kigali, Rwanda',
+      destination: 'Nairobi, Kenya',
+      travelDate: '2020-02-29',
+      reason: 'lifeisshortjust chill',
+      accommodation_id: 3,
+      rememberMe: false
+    })
+    .end((error, response) => {
+      expect(response).to.have.status(201);
+      expect(response.body).to.be.a('object');
+      expect(response.body.status).to.be.equal(201);
+      done(error);
+    });
+});
+
+it('You can\'t request trip when you don\'t provide full information ', (done) => {
+  request(server)
+    .post('/api/requests/one_way')
+    .set({ token: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJuYW1lQGV4YW1wbGUuY29tIiwiaWF0IjoxNTgwODkyNDM5fQ.xGAHCjyRKSGcsVHqiLGASfwGxmQHsNYRL_GY3uS34Ks' })
+    .send({ origin: 'Kigali, Rwanda' })
+    .end((error, response) => {
+      expect(response).to.have.status(400);
+      expect(response.body).to.be.a('object');
+      expect(response.body.status).to.be.equal(400);
+      done(error);
+    });
+});

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -9,6 +9,7 @@ import verification from './email.verification.test';
 import assignRole from './assignRole.test';
 import socialLogin from './socialLogin.test';
 import notification from './notification.test';
+import autoFill from './autoFill.test';
 
 describe('API test', () => {
   describe('Server test', server);
@@ -22,4 +23,5 @@ describe('API test', () => {
   describe('Register test', assignRole);
   describe('Social Login test', socialLogin);
   describe('Notification test', notification);
+  describe('Remember user information', autoFill);
 });


### PR DESCRIPTION
#### What does this PR do?
Have auto-fill functionality
#### Description of Task to be completed?
When the user clicks on remember me, He won't provide his details at every travel request initiation. However, if you don't click on remember me checkbox, you will provide your details every time you request a trip.
#### How should this be manually tested?
Clone this repo, cd into the project directory and run the following commands:
 - npm install
 - npm start
open postman and send post request in this URL (localhost:5000/api/requests/one_way)
#### What are the relevant pivotal tracker stories?
[#170764593](https://www.pivotaltracker.com/story/show/170764593)
> Input for the first time
{
  "passportName":  "Paul Beer",
  "passportNumber":  198700650,
  "gender":  "Female",
  "role":  "requester",
  "dob":  "12/Nov/1673",
  "origin": "Kigali, Rwanda",
  "destination": "Nairobi, Kenya",
  "travelDate": "2020-02-29",
  "reason": "life is short, just chill",
  "accommodation_id": 3,
  "rememberMe": true
}
 Input for the second time
{
  "origin": "Kigali, Rwanda",
  "destination": "Nairobi, Kenya",
  "travelDate": "2020-02-29",
  "reason": "life is short, just chill",
  "accommodation_id": 3,
}
