### PR TITLE
#170764597: Like or unlike accommodation facility

### DIFF
--- a/src/controllers/LikeController.js
+++ b/src/controllers/LikeController.js
@@ -1,0 +1,81 @@
+/* eslint-disable class-methods-use-this */
+import Response from '../utils/response';
+import LikeService from '../repositories/LikeRepository';
+
+class LikeController {
+  /**
+   * like or unlike accomodation facility
+   * @param {object} req accommodation
+   * @param {object} res response
+   * @returns {object} response object
+   */
+  static async LikeOrUnlike(req, res) {
+    let accommodation;
+    let alreadyLiked;
+    try {
+      const { userData } = req;
+      const AccommodationId = Number(req.params.id);
+
+      accommodation = await LikeService.checkAccommodation(AccommodationId);
+      if (!accommodation) {
+        const response = new Response(res, 404, 'accommodation not found');
+        return response.sendErrorMessage();
+      }
+      alreadyLiked = await LikeService.checkLikes({
+        user_id: userData.id,
+        accommodation_id: AccommodationId
+      });
+      if (alreadyLiked.length > 0) {
+        await LikeService.unLike({ user_id: userData.id, accommodation_id: AccommodationId });
+        const response = new Response(res, 201, `You have unliked ${accommodation.name}`);
+        return response.sendSuccessMessage();
+      }
+      const addedLike = await LikeService.Like({
+        user_id: userData.id,
+        accommodation_id: AccommodationId,
+      }, {
+        fields: ['user_id', 'accommodation_id']
+      });
+
+      if (addedLike) {
+        const response = new Response(res, 201, `You have liked ${accommodation.name}`);
+        return response.sendSuccessMessage();
+      }
+    } catch (err) {
+      const response = new Response(res, 500, err || 'Internal server error');
+      return response.sendErrorMessage();
+    }
+  }
+
+  /**
+   * @description fetch all likes of a certain accommodation
+   * @param {object} req accommodation
+   * @param {object} res response
+   * @returns {object} response object
+   */
+
+  static async countAccommodationLikes(req, res) {
+    let accommodation;
+    let Likes;
+    try {
+      const AccommodationId = Number(req.params.id);
+
+      accommodation = await LikeService.checkAccommodation(AccommodationId);
+      if (!accommodation) {
+        const response = new Response(res, 404, 'accommodation not found');
+        return response.sendErrorMessage();
+      }
+      Likes = await LikeService.accommodationLikes(AccommodationId);
+      if (!Likes) {
+        const response = new Response(res, 404, 'Likes not found for this accommodation');
+        return response.sendErrorMessage();
+      }
+      const response = new Response(res, 200, `${accommodation.name} Likes sucessfully fetched `, { likes: Likes });
+      response.sendSuccessResponse();
+    } catch (err) {
+      const response = new Response(res, 500, err || 'Internal server error');
+      return response.sendErrorMessage();
+    }
+  }
+}
+export default LikeController;

--- a/src/database/migrations/20200204141154-create-accomodation.js
+++ b/src/database/migrations/20200204141154-create-accomodation.js
@@ -45,7 +45,7 @@ export default {
     status: {
       type: Sequelize.STRING,
       allowNull: false,
-      defaultValue: 'Pending',
+      defaultValue: 'Pending'
     },
     createdAt: {
       allowNull: false,
@@ -56,7 +56,7 @@ export default {
       allowNull: false,
       type: Sequelize.DATE,
       defaultValue: Sequelize.fn('NOW')
-    },
+    }
   }),
 
   down: queryInterface => queryInterface.dropTable('Accommodation')

--- a/src/database/migrations/20200210152349-create-like.js
+++ b/src/database/migrations/20200210152349-create-like.js
@@ -1,0 +1,39 @@
+export default {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Like', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    user_id: {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'user_id',
+      },
+    },
+    accommodation_id: {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      onDelete: 'CASCADE',
+      references: {
+        model: 'Accommodation',
+        key: 'id',
+        as: 'accommodation_id',
+      },
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Like')
+};

--- a/src/database/seeders/20200121122716-create-user.js
+++ b/src/database/seeders/20200121122716-create-user.js
@@ -129,16 +129,8 @@ export default {
     role: 'requester',
     password: await hashPassword('skemc1234'),
     isVerified: true
-  },
-  {
-    email: 'elvissoftdeveloper@gmail.com',
-    user_name: 'Elvis Soft Developer',
-    role: 'requester',
-    password: await hashPassword('Kemmy123'),
-    line_manager: 'elvisrugamba@gmail.com',
-    isVerified: true,
-    emailNotification: true
-  }], {}),
+  }
+  ], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Users', null, {})
 };

--- a/src/database/seeders/20200203041347-create-accomodation.js
+++ b/src/database/seeders/20200203041347-create-accomodation.js
@@ -1,7 +1,7 @@
 export default {
   up: queryInterface => queryInterface.bulkInsert('Accommodation', [
     {
-      user_id: 11,
+      user_id: 14,
       name: 'John Doe',
       address: 'rwanda, kigali',
       rooms: 56,
@@ -9,10 +9,12 @@ export default {
       geo_location: '10.84854, 20.234708',
       services: ['conference hall', 'entertainment'],
       amenities: ['WIFI', 'WIFI'],
-      description: 'Good'
+      description: 'Good',
+      createdAt: new Date(),
+      updatedAt: new Date(),
     },
     {
-      user_id: 11,
+      user_id: 14,
       name: 'serena hotel',
       address: 'rwanda, kigali',
       rooms: 34,
@@ -20,7 +22,9 @@ export default {
       geo_location: '10.84854, 20.234708',
       services: ['conference hall', 'entertainment'],
       amenities: ['WIFI', 'WIFI'],
-      description: 'Good'
+      description: 'Good',
+      createdAt: new Date(),
+      updatedAt: new Date(),
     }], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Accommodation', null, {})

--- a/src/database/seeders/20200204232743-notification.js
+++ b/src/database/seeders/20200204232743-notification.js
@@ -30,7 +30,7 @@ export default {
     message: 'New equest has been created, waiting for approval'
   },
   {
-    user_id: 17,
+    user_id: 11,
     request_id: 4,
     type: 'Approved',
     message: 'Your request has been approved'

--- a/src/database/seeders/20200211090818-create-like.js
+++ b/src/database/seeders/20200211090818-create-like.js
@@ -1,0 +1,16 @@
+export default {
+  up: queryInterface => queryInterface.bulkInsert('Like', [{
+    user_id: 9,
+    accommodation_id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  },
+  {
+    user_id: 2,
+    accommodation_id: 1,
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }], {}),
+
+  down: queryInterface => queryInterface.bulkDelete('Like', null, {})
+};

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ export default (app) => {
   app.use('/api/accommodations', accommodation);
   app.use('/api/accommodations', Feeback);
 
-
   app.use((req, res, next) => {
     const err = new Error('Page not found');
     err.status = 404;

--- a/src/models/accommodation.js
+++ b/src/models/accommodation.js
@@ -42,17 +42,22 @@ export default (sequelize, DataTypes) => {
       defaultValue: 'Pending',
       validate: {
         isIn: {
-          args: [['Pending', 'Approved']],
+          args: [
+            ['Pending', 'Approved']
+          ],
           msg: 'Invalid Status, uses Pending, Approved or Rejected only'
         }
       }
     },
   }, {});
-
   Accommodation.associate = models => {
-    Accommodation.hasMany(models.Request, { foreignKey: 'accommodation_id', as: 'requests' });
     Accommodation.hasMany(models.Feedback, { foreignKey: 'accommodation_id', as: 'feedbacks' });
+    Accommodation.belongsTo(models.User, { foreignKey: 'user_id' });
+    Accommodation.hasMany(models.Like, {
+      foreignKey: 'accommodation_id',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    });
   };
-
   return Accommodation;
 };

--- a/src/models/like.js
+++ b/src/models/like.js
@@ -1,0 +1,35 @@
+export default (sequelize, DataTypes) => {
+  const Like = sequelize.define(
+    'Like', {
+      user_id: {
+        allowNull: false,
+        type: DataTypes.INTEGER
+      },
+      accommodation_id: {
+        allowNull: false,
+        type: DataTypes.INTEGER
+      },
+      createdAt: {
+        allowNull: false,
+        type: DataTypes.DATE
+      },
+      updatedAt: {
+        allowNull: true,
+        type: DataTypes.DATE
+      }
+    },
+    {}
+  );
+
+  Like.associate = (models) => {
+    Like.belongsTo(models.Accommodation, {
+      foreignKey: 'accommodation_id',
+      onDelete: 'CASCADE'
+    });
+    Like.belongsTo(models.User, {
+      foreignKey: 'user_id',
+      onDelete: 'CASCADE'
+    });
+  };
+  return Like;
+};

--- a/src/repositories/LikeRepository.js
+++ b/src/repositories/LikeRepository.js
@@ -1,0 +1,101 @@
+/* eslint-disable camelcase */
+/* eslint-disable no-useless-catch */
+import database from '../models';
+
+const { Like, Accommodation } = database;
+
+class LikeRepository {
+  /**
+   * Creates a new Like.
+   * @param {object} user_id
+   * @param {object} accommodation_id
+   * @returns {object} Like.
+   */
+  static async Like({ user_id, accommodation_id }) {
+    try {
+      const result = await Like.create({
+        user_id,
+        accommodation_id
+      }, {
+        fields: ['user_id', 'accommodation_id']
+      });
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * check if accommodation exists.
+   * @param {object} accommodation_id .
+   * @returns {object} Like object.
+   */
+  static async checkAccommodation(accommodation_id) {
+    try {
+      const result = await Accommodation.findOne({
+        where: { id: accommodation_id }
+      });
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  /**
+   * Check if like exists by user id and accommodatio id.
+   * @param {object} user_id.
+   * @param {object} accommodation_id.
+   * @returns {object} Like object.
+   */
+  static async checkLikes({ user_id, accommodation_id }) {
+    try {
+      const result = await Like.findAll({
+        where:
+          {
+            user_id, accommodation_id
+          }
+      });
+      return result;
+    } catch (error) {
+      throw (error);
+    }
+  }
+
+  /**
+   * Counting likes on a certain accommodation
+   * @param {object} accommodation_id
+   * @returns {object} Like object.
+   */
+  static async accommodationLikes(accommodation_id) {
+    try {
+      const result = await Like.count({
+        where: [
+          {
+            accommodation_id
+          }
+        ]
+      });
+      return result;
+    } catch (error) {
+      throw (error);
+    }
+  }
+  /**
+   * unliking an accommodation
+   * @param {object} user_id
+   * @param {object} accommodation_id
+   * @returns {object} delete object.
+   */
+
+  static async unLike({ user_id, accommodation_id }) {
+    try {
+      const result = await Like.destroy({
+        where: [{ user_id, accommodation_id }]
+      });
+      return result;
+    } catch (error) {
+      throw error;
+    }
+  }
+}
+export default LikeRepository;

--- a/src/repositories/commentRepository.js
+++ b/src/repositories/commentRepository.js
@@ -26,7 +26,10 @@ class CommentRepository {
   static async getCommentsByRequest(id) {
     try {
       return await Comment.findAll({
-        where: { request_id: id }
+        where: { request_id: id },
+        order: [
+          ['createdAt', 'DESC'],
+        ]
       });
     } catch (error) {
       throw new Error(error);

--- a/src/routes/accommodation.route.js
+++ b/src/routes/accommodation.route.js
@@ -2,6 +2,7 @@ import express from 'express';
 import connect from 'connect-multiparty';
 import Accommodation from '../controllers/accommodation.controller';
 import AuthMiddleware from '../middlewares/auth.middleware';
+import LikeController from '../controllers/LikeController';
 import AccommodationMiddleware from '../middlewares/accommodation.middleware';
 
 const router = express.Router();
@@ -11,5 +12,7 @@ router.post('/', AuthMiddleware.verifyToken, AccommodationMiddleware.isHost, con
 router.patch('/:id/approve', AuthMiddleware.verifyToken, AuthMiddleware.isSuperAdmin, AccommodationMiddleware.param, Accommodation.accommodationApprove);
 router.get('/', AuthMiddleware.verifyToken, Accommodation.getAllAccommodation);
 router.get('/:id', AuthMiddleware.verifyToken, AccommodationMiddleware.param, Accommodation.getSpecificAccommodation);
+router.post('/:id/like', AuthMiddleware.verifyToken, LikeController.LikeOrUnlike);
+router.get('/:id/likes', AuthMiddleware.verifyToken, LikeController.countAccommodationLikes);
 
 export default router;


### PR DESCRIPTION

### What does this PR do?
Enables a user to like accommodation
Enables a user to unlike accommodation
### Description of Task to be completed?
add like to accommodation
remove like to accommodation
check if accommodation to liked or unliked is available
### How should this be manually tested?
git clone this repo and check out to `ft-like-unlike-accomodation-170764597`
run `npm I` to install all the dependencies
run sequelize db:migrate:undo: all then npm run migrate to add the like schema
run the application with npm run dev
register accommodation in the system

login the user and user the token provided in subsequent operations
- Use Postman: send a POST request to `/accommodations/:id/like`  
### Any background context you want to provide?
N/A
What are the relevant pivotal tracker stories?
#170764597

Screenshots (if appropriate)

![like](https://user-images.githubusercontent.com/50500123/74413606-6954d300-4e48-11ea-9919-99f723566da5.PNG)
