### PR TITLE
#171408876 Fix Notification for Request Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^1.19.0",
     "cloudinary": "^1.19.0",
     "connect-multiparty": "^2.2.0",
+    "cors": "^2.8.5",
     "country-list": "^2.2.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -33,7 +34,8 @@
     "sinon": "^8.1.1",
     "socket.io": "^2.3.0",
     "socket.io-client": "^2.3.0",
-    "swagger-ui-express": "^4.1.3"
+    "swagger-ui-express": "^4.1.3",
+    "web-push": "^3.4.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.3",

--- a/public/client.html
+++ b/public/client.html
@@ -81,8 +81,20 @@
         }
 
         li {
+            width: 100%;
+            display: block;
             position: relative;
             padding: 10px;
+        }
+
+        .badge {
+            width: 20px;
+            display: inline-block;
+            background-color: #ccc;
+            border: 1px solid #ccc;
+            border-radius: 50;
+            padding: 3px 6px;
+            font-size: 24px;
         }
     </style>
 </head>
@@ -97,15 +109,47 @@
         </form>
     </div>
     <div class="card">
-        <h1 class="title">Notifications</h1>
+        <h1 class="title">Notifications <span class="badge">0</span></h1>
         <div class="form">
             <ul id="notifications">
             </ul>
         </div>
     </div>
-    <script src="http://localhost:5000/socket.io/socket.io.js"></script>
-    <script>
-        const socket = io.connect(window.location.host);
+    <script src="/socket.io/socket.io.js"></script>
+    <script src="./notification.js"></script>
+    <script defer>
+        const socket = io();
+        let notificationsCount = 0;
+
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker.register('/notification.js', { scope: '/' });
+            navigator.serviceWorker.ready
+                .then(registration => {
+                    console.log(`Registration succeeded. Scope is ${registration.scope}`);
+                    return registration.addEventListener('install', () => {
+                        registration.skipWaiting();
+                        clients.claim();
+                    });
+                })
+                .catch(error => console.log('Service worker registration failed:', error));
+        } else {
+            console.log('Service workers are not supported.');
+        }
+
+        if ("Notification" in window) {
+            if (Notification.permission === "granted") {
+                console.log("Permission to receive notifications is already granted");
+            } else {
+                Notification.requestPermission(permission => {
+                    if (permission === "granted") {
+                        console.log("Permission to receive notifications has been granted");
+                    }
+                });
+            }
+        } else {
+            console.error("This browser does not support desktop notification");
+        }
+
         socket.on('connect', () => {
             document.querySelector('#connStatus').textContent = 'Server Connected!';
         });
@@ -114,44 +158,40 @@
         });
         socket.on('welcome', data => {
             document.querySelector('#title').textContent = data;
-            socket.emit('check delay', Date.now());
         });
         document.querySelector("form").addEventListener('submit', event => {
             event.preventDefault();
             const id = document.querySelector("input").value;
             socket.emit('join notification', { id: `notification_${id}` });
-            socket.emit('test', `notification_${id}`);
         });
         socket.on('created_request', data => {
-            socket.emit('check delay', data.time);
-            const list = document.createElement('li');
-            list.appendChild(document.createTextNode(JSON.stringify(data)));
-            document.querySelector('#notifications').appendChild(list);
+            notificationsCount += 1;
+            showNotification(data);
         });
-        socket.on('updated_request', data => {
-            socket.emit('check delay', data.time);
-            const list = document.createElement('li');
-            list.appendChild(document.createTextNode(JSON.stringify(data)));
-            document.querySelector('#notifications').appendChild(list);
+        socket.on('edited_request', data => {
+            notificationsCount += 1;
+            showNotification(data);
         });
         socket.on('approved_request', data => {
-            socket.emit('check delay', data.time);
-            const list = document.createElement('li');
-            list.appendChild(document.createTextNode(JSON.stringify(data)));
-            document.querySelector('#notifications').appendChild(list);
+            notificationsCount += 1;
+            showNotification(data);
         });
         socket.on('rejected_request', data => {
-            socket.emit('check delay', data.time);
-            const list = document.createElement('li');
-            list.appendChild(document.createTextNode(JSON.stringify(data)));
-            document.querySelector('#notifications').appendChild(list);
+            notificationsCount += 1;
+            showNotification(data);
         });
         socket.on('commented_request', data => {
-            socket.emit('check delay', data.time);
+            notificationsCount += 1;
+            showNotification(data);
+        });
+
+        const showNotification = data => {
+            pushNotification(data);
+            document.querySelector('.badge').textContent = notificationsCount
             const list = document.createElement('li');
             list.appendChild(document.createTextNode(JSON.stringify(data)));
             document.querySelector('#notifications').appendChild(list);
-        });
+        }
     </script>
 </body>
 

--- a/public/notification.js
+++ b/public/notification.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-plusplus */
+/* eslint-disable no-restricted-globals */
+/* eslint-disable no-console */
+/* eslint-disable no-undef */
+/* eslint-disable no-unused-vars */
+const openNotification = (registration, notification) => {
+  registration.getNotifications()
+    .then(notifications => {
+      let currentNotification;
+
+      for (let i = 0; i < notifications.length; i++) {
+        if (notifications[i].data
+          && notifications[i].data.type === notification.type) {
+          currentNotification = notifications[i];
+        }
+      }
+
+      return currentNotification;
+    }).then(currentNotification => {
+      const options = {
+        icon: 'https://res.cloudinary.com/elvis-rugamba/image/upload/v1582304341/z35smnjcnwpmukrr8lob.png',
+        badge: 'https://res.cloudinary.com/elvis-rugamba/image/upload/v1582304341/z35smnjcnwpmukrr8lob.png',
+        timestamp: new Date(Date.now()).toString(),
+        tag: 'Barefoot-Nomad',
+        dir: 'ltr'
+      };
+
+      if (currentNotification) {
+        const notificationCount = currentNotification.data.count + 1;
+
+        notification.count = notificationCount;
+        options.body = `There are ${notificationCount} ${notification.type} requests.`;
+        currentNotification.close();
+      } else {
+        notification.count = 1;
+        options.body = notification.message;
+      }
+
+      notificationTitle = notification.type;
+      options.data = notification;
+
+      return registration.showNotification(notificationTitle, options);
+    }).catch(error => { throw new Error(error); });
+};
+
+const pushNotification = notification => {
+  if (!('Notification' in window)) {
+    console.error('This browser does not support desktop notification');
+  } else if (Notification.permission === 'granted') {
+    navigator.serviceWorker.ready.then(registration => {
+      registration.showNotification(notification.type, {
+        body: notification.message,
+        data: notification,
+        icon: 'https://res.cloudinary.com/elvis-rugamba/image/upload/v1582304341/z35smnjcnwpmukrr8lob.png',
+        badge: 'https://res.cloudinary.com/elvis-rugamba/image/upload/v1582304341/z35smnjcnwpmukrr8lob.png',
+        timestamp: new Date(Date.now()).toString(),
+        dir: 'ltr'
+      });
+      // openNotification(registration, notification);
+    }).catch(error => console.log('Notification failed wtih', error));
+  } else if (Notification.permission !== 'denied') {
+    navigator.serviceWorker.ready.then(registration => {
+      registration.showNotification(notification.type, {
+        body: notification.message,
+        data: notification,
+        icon: 'https://res.cloudinary.com/elvis-rugamba/image/upload/v1582304341/z35smnjcnwpmukrr8lob.png',
+        badge: 'https://res.cloudinary.com/elvis-rugamba/image/upload/v1582304341/z35smnjcnwpmukrr8lob.png',
+        timestamp: new Date(Date.now()).toString(),
+        dir: 'ltr'
+      });
+      // openNotification(registration, notification);
+    }).catch(error => console.log('Notification failed wtih', error));
+  }
+};
+
+self.addEventListener('notificationclick', event => {
+  const baseUrl = event.currentTarget.origin;
+  const url = `${baseUrl}/${event.notification.data.link}`;
+
+  event.notification.close();
+  event.waitUntil(clients.matchAll({ type: 'window' }).then(clientList => {
+    for (let i = 0; i < clientList.length; i++) {
+      const client = clientList[i];
+      if (client.url === url && 'focus' in client) return client.focus();
+    }
+    if (clients.openWindow) return clients.openWindow(url);
+  }));
+});

--- a/src/app.js
+++ b/src/app.js
@@ -4,11 +4,13 @@ import morgan from 'morgan';
 import bodyparser from 'body-parser';
 import { serve, setup } from 'swagger-ui-express';
 import path from 'path';
+import cors from 'cors';
 import swagger from './swagger.json';
 
 dotenv.config();
 
 const app = express();
+
 app.use(morgan('combined'));
 app.use(bodyparser.json());
 app.use(bodyparser.urlencoded({ extended: true }));
@@ -22,6 +24,8 @@ app.get('/', (req, res) => {
     message: 'welcome to barefoot nomad'
   });
 });
+
+app.use(cors());
 
 require('./index.js')(app);
 

--- a/src/controllers/commentController.js
+++ b/src/controllers/commentController.js
@@ -15,6 +15,7 @@ class CommentController {
    */
   static async addComment(req, res, next) {
     try {
+      const { userData } = req;
       const { comment } = req.body;
       const requestID = Number(req.params.id);
       const requestExists = await RequestService.findRequestById(requestID);
@@ -22,7 +23,7 @@ class CommentController {
         const response = new Response(res, 404, 'Request is not found to add a comment');
         return response.sendErrorMessage();
       }
-      const user = await UserService.findByUserId(req.userData.id);
+      const user = await UserService.findByUserId(userData.id);
       const addedComment = await CommentService.addComment({
         user_id: user.id,
         request_id: requestID,
@@ -34,10 +35,7 @@ class CommentController {
       const notification = {
         eventType: 'commented_request',
         requestId: requestID,
-        receiver: requestExists.user,
-        type: 'Commented',
-        message: 'Your request has been commented on',
-        link: `${req.headers.host}/api/requests/${requestID}`
+        role: userData.role
       };
 
       eventEmitter.emit('notification', notification);

--- a/src/controllers/requestController.js
+++ b/src/controllers/requestController.js
@@ -7,7 +7,6 @@ import AuthUtils from '../utils/auth.utils';
 import RequestRepository from '../repositories/requestRepository';
 import RequestServices from '../services/trip.services';
 import { eventEmitter } from '../utils/event.util';
-import userRepository from '../repositories/userRepository';
 import DestinationService from '../repositories/DestinationRepo';
 import pagination from '../utils/pagination.utils';
 
@@ -55,11 +54,7 @@ class RequestController {
 
         const notification = {
           eventType: 'rejected_request',
-          requestId,
-          receiver: lineManager,
-          type: 'Rejected',
-          message: 'Your request has been rejected',
-          link: `${req.headers.host}/api/requests/${requestId}`
+          requestId
         };
 
         eventEmitter.emit('notification', notification);
@@ -119,15 +114,9 @@ class RequestController {
       const { dataValues } = await Request.create(info);
 
       if (dataValues) {
-        const user = await userRepository.findById(userData.id);
-        const lineManager = await userRepository.findByEmail(user.line_manager);
         const notification = {
           eventType: 'created_request',
-          requestId: dataValues.id,
-          receiver: lineManager,
-          type: 'Created',
-          message: 'New request has been created, waiting for approval',
-          link: `${req.headers.host}/api/requests/${dataValues.id}`
+          requestId: dataValues.id
         };
 
         eventEmitter.emit('notification', notification);
@@ -292,10 +281,15 @@ class RequestController {
       const id = parseInt(req.params.id, 10);
       let response;
       const directReportIds = await RequestService.retrieveDirectReports(userData);
-      const { user_id: userId, user } = await RequestRepository.findById(id);
+      const { user_id: userId, status } = await RequestRepository.findById(id);
 
       if (directReportIds.length === 0 || !userId || !directReportIds.includes(userId)) {
         response = new Response(res, 404, 'Request not found in your direct reports');
+        return response.sendErrorMessage();
+      }
+
+      if (status === 'Approved') {
+        response = new Response(res, 400, 'Request is already approved');
         return response.sendErrorMessage();
       }
 
@@ -309,13 +303,10 @@ class RequestController {
           }
         );
       });
+
       const notification = {
         eventType: 'approved_request',
-        requestId: id,
-        receiver: user,
-        type: 'Approved',
-        message: 'Your request has been approved',
-        link: `${req.headers.host}/api/requests/${id}`
+        requestId: id
       };
 
       eventEmitter.emit('notification', notification);
@@ -401,14 +392,9 @@ class RequestController {
           });
         }
 
-        const lineManager = await userRepository.findByEmail(user.line_manager);
         const notification = {
-          eventType: 'updated_request',
-          requestId,
-          receiver: lineManager,
-          type: 'Updated',
-          message: 'Request has been updated',
-          link: `${req.headers.host}/api/requests/${requestId}`
+          eventType: 'edited_request',
+          requestId
         };
 
         eventEmitter.emit('notification', notification);
@@ -432,8 +418,10 @@ class RequestController {
   /**
    * @description This methods helps travelers and managers get statistics of
    * trips made in certain range of time
+   * @param {object} req the request sent to the server
+   * @param {object} res the response returned
+   * @returns  {object} The response object
   */
-
   static async getTripStatistics(req, res) {
     let tripStatistics;
     let response;

--- a/src/database/seeders/20200121122716-create-user.js
+++ b/src/database/seeders/20200121122716-create-user.js
@@ -53,7 +53,8 @@ export default {
     user_name: 'great',
     role: 'manager',
     password: await hashPassword('Kemmy123'),
-    isVerified: true
+    isVerified: true,
+    emailNotification: true
   },
   {
     email: 'elvis@gmail.com',

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,6 @@ export default (app) => {
   app.use('/api/chat', chat);
   app.use('/api/accommodations', Rating);
 
-
   app.use((req, res, next) => {
     const err = new Error('Page not found');
     err.status = 404;

--- a/src/middlewares/tripValues.js
+++ b/src/middlewares/tripValues.js
@@ -71,7 +71,7 @@ export default class TripValues {
 
       next();
     } catch (error) {
-      const response = new Response(res, 500, error);
+      const response = new Response(res, 500, error.message);
       return response.sendErrorMessage();
     }
   }

--- a/src/services/notification.service.js
+++ b/src/services/notification.service.js
@@ -2,6 +2,7 @@
 import { io } from '../server';
 import NotificationRepository from '../repositories/notification.repository';
 import Mailer from '../utils/mailer.util';
+import NotificationUtils from '../utils/notification.utils';
 
 const notificationRepository = new NotificationRepository();
 
@@ -19,14 +20,9 @@ class NotificationService {
    * @param { String } link
    * @returns { obj } Notification record
    */
-  static async send({
-    eventType, requestId, receiver, type, message, link
-  }) {
+  static async send({ eventType, requestId, role }) {
     try {
-      const notification = {
-        user_id: receiver.id, request_id: requestId, type, message, link
-      };
-
+      const { notification, receiver } = await NotificationUtils(eventType, requestId, role);
       const record = await notificationRepository.create(notification);
 
       notification.id = record.id;
@@ -53,7 +49,7 @@ class NotificationService {
       }
 
       if (receiver.emailNotification) {
-        const mailer = new Mailer('Barefoot Nomad notification', receiver, message, link);
+        const mailer = new Mailer('Barefoot Nomad Notification', receiver, notification.message, notification.link);
         mailer.sendMail();
       }
 

--- a/src/utils/mailer.util.js
+++ b/src/utils/mailer.util.js
@@ -76,7 +76,7 @@ class Mailer {
                     <p>${this.message}</p>
                 </div>
             </div>
-            <a href=${this.url}>
+            <a href='https://barefoot-nomad-staging.herokuapp.com/${this.url}'>
                 <button class="EmailView-btn">Show Notification</button>
             </a>
         </div>

--- a/src/utils/notification.utils.js
+++ b/src/utils/notification.utils.js
@@ -1,0 +1,75 @@
+import RequestRepository from '../repositories/requestRepository';
+import userRepository from '../repositories/userRepository';
+
+export default async (eventType, requestId, role) => {
+  let notification = {};
+  let receiver;
+  const { user } = await RequestRepository.findById(requestId);
+  let lineManager;
+
+  if (eventType === 'created_request' || eventType === 'edited_request') {
+    lineManager = await userRepository.findByEmail(user.line_manager);
+    receiver = lineManager;
+  } else if (eventType === 'commented_request') {
+    if (role === 'manager') {
+      receiver = user;
+    } else {
+      lineManager = await userRepository.findByEmail(user.line_manager);
+      receiver = lineManager;
+    }
+  } else {
+    receiver = user;
+  }
+
+  switch (eventType) {
+    case 'created_request':
+      notification = {
+        user_id: lineManager.id,
+        request_id: requestId,
+        type: 'Created',
+        message: 'New request has been created, waiting for approval',
+        link: `api/requests/${requestId}`
+      };
+      break;
+    case 'edited_request':
+      notification = {
+        user_id: lineManager.id,
+        request_id: requestId,
+        type: 'Updated',
+        message: 'Request has been updated',
+        link: `api/requests/${requestId}`
+      };
+      break;
+    case 'approved_request':
+      notification = {
+        user_id: user.id,
+        request_id: requestId,
+        type: 'Approved',
+        message: 'Your request has been approved',
+        link: `api/requests/${requestId}`
+      };
+      break;
+    case 'rejected_request':
+      notification = {
+        user_id: user.id,
+        request_id: requestId,
+        type: 'Rejected',
+        message: 'Your request has been rejected',
+        link: `api/requests/${requestId}`
+      };
+      break;
+    case 'commented_request':
+      notification = {
+        user_id: user.id,
+        request_id: requestId,
+        type: 'Commented',
+        message: 'Request has been commented on',
+        link: `api/requests/${requestId}/comment`
+      };
+      break;
+    default:
+      break;
+  }
+
+  return { notification, receiver };
+};


### PR DESCRIPTION
#### What does this PR do?
- Have Notification for Request Updates implemented with service worker
#### Description of Task to be completed?
- Add service worker and notification API functionality
- Refactor codes
#### How should this be manually tested?
- You have to clone the repo `git clone https://github.com/Stackup-Rwanda/fan7-bn-backend.git`
- Then After the repo cloned `cd project-folder` and run `npm i` to install all dependencies
- Run app by `npm run dev`
- Open your browser and browse `localhost:5000/client.html`
- For the first time you should see a popup menu asks for permission to receive notification from the app. Allow the permission.
- Provide a receiver id
- In postman, `Create/Edit/Approve/Reject/comment` a request and you should see a popup window shows the notification.
#### Any background context you want to provide?
Web push notifications allow users to opt-in to timely updates from our app.
The Notification API open a whole new set of possibilities  to re-engage with your users.
Push notification is based on service workers because service workers operate in the background. This means the only time code is run for a push notification is when the user interacts with a notification by clicking it or closing it.
Instead of using Push API, We are using socket.io to receive notification updates from the server and then triggers the push notification.
#### What are the relevant pivotal tracker stories?
[#171408876](https://www.pivotaltracker.com/story/show/171408876)
#### Screenshots (if appropriate)
![Screenshot (65)](https://user-images.githubusercontent.com/55624349/75113321-9f1e6680-5655-11ea-80eb-8833a2558ed7.png)

#### Questions 
N/A