### PR TITLE
 #171443039 fix bug on reject specific request by manager

### DIFF
--- a/src/database/seeders/20200203063041-create-request.js
+++ b/src/database/seeders/20200203063041-create-request.js
@@ -98,6 +98,19 @@ export default {
     accommodation_id: 1,
     reason: 'life is short, just chill',
     status: 'Pending'
+  },
+  {
+    user_id: 7,
+    passportName: 'Boris Bihire',
+    passportNumber: 198700,
+    gender: 'Female',
+    dob: '2020-02-19T07:24:22.510Z',
+    origin: 'Rwanda, Kigali',
+    destination: ['Kenya, Nairobi'],
+    travel_date: ['2020-10-29'],
+    accommodation_id: 1,
+    reason: 'life is short, just chill',
+    status: 'Approved'
   }], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Requests', null, {})


### PR DESCRIPTION
#### What does this PR do?
This PR fixes bugs on reject requests by the line manager endpoint.
#### Description of Task to be completed?
Have manager be able to reject a request if it is found in his report
- Check if the user is a manager.
- Check if the request he is trying to reject is found in his direct report
- Check if the request is not rejected already
- Reject request
#### How should this be manually tested?
- You have to clone the repo `git clone https://github.com/Stackup-Rwanda/fan7-bn-backend.git`
- Then After the repo cloned `cd project-folder` and run `npm i` to install all dependencies
- Run app by `npm run dev`
- Use Postman to test the endpoint, then type the following in URL `PATCH: localhost:5000/api/requests/:request_id/reject`
#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#171443039](https://www.pivotaltracker.com/story/show/171443039)
